### PR TITLE
Support worker in service mesh

### DIFF
--- a/charts/laravel-worker/Chart.yaml
+++ b/charts/laravel-worker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/laravel-worker/README.md
+++ b/charts/laravel-worker/README.md
@@ -32,7 +32,7 @@ Install Laravel Worker chart:
 ```bash
 $ helm upgrade laravel-horizon \
     --install \
-    --version=1.0.0 \
+    --version=1.1.0 \
     renoki-co/laravel-worker
 ```
 

--- a/charts/laravel-worker/templates/deployment.yaml
+++ b/charts/laravel-worker/templates/deployment.yaml
@@ -73,6 +73,12 @@ spec:
             {{- with .Values.app.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- if .Values.service.enabled }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- end }}
           resources:
             {{- toYaml .Values.app.resources | nindent 12 }}
           {{- with .Values.app.extraEnv }}

--- a/charts/laravel-worker/templates/service.yaml
+++ b/charts/laravel-worker/templates/service.yaml
@@ -18,5 +18,5 @@ spec:
       name: http
   selector:
     {{- include "laravel-worker.selectorLabels" . | nindent 4 }}
-    laravel.com/pod-type: web
+    laravel.com/pod-type: worker
 {{- end }}


### PR DESCRIPTION
I have been using successfully this chart to deploy Laravel applications on Kubernetes with Consul service mesh. However there are a couple of fixes required to make the worker recognised by Consul:

- `laravel.com/pod-type` annotation for the worker service is set incorrectly to `web`, now changed to `worker` to match the deployment
- if the service is enabled for the worker then add a matching port on the deployment so that the underlying pods can communicate over the mesh (e.g. the worker could reach a DB exposed on the mesh according to specific authorisation policies/intentions)
